### PR TITLE
feat : 독서 기록

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './user/user.module';
 import { BookModule } from './book/book.module';
+import { HistoryModule } from './history/history.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { BookModule } from './book/book.module';
     }),
     UserModule,
     BookModule,
+    HistoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/history/dtos/CreateUserBookHistory.dto.ts
+++ b/src/history/dtos/CreateUserBookHistory.dto.ts
@@ -1,0 +1,19 @@
+import { IsNumber } from 'class-validator';
+
+export class CreateUserBookHistoryDto {
+  @IsNumber()
+  bookshelfBookId: number;
+  //userId : number 요청 토큰으로 받으면 됨
+
+  @IsNumber()
+  startPage: number;
+
+  @IsNumber()
+  endPage: number;
+
+  @IsNumber()
+  duration: number; //단위 s
+
+  @IsNumber()
+  coins: number; //얻은 코인 수
+}

--- a/src/history/history.controller.spec.ts
+++ b/src/history/history.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HistoryController } from './history.controller';
+
+describe('HistoryController', () => {
+  let controller: HistoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HistoryController],
+    }).compile();
+
+    controller = module.get<HistoryController>(HistoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/history/history.controller.ts
+++ b/src/history/history.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Post, Body, Req, HttpStatus } from '@nestjs/common';
+import { HistoryService } from './history.service';
+import { CreateUserBookHistoryDto } from './dtos/CreateUserBookHistory.dto';
+import { Request } from 'express';
+
+@Controller('history')
+export class HistoryController {
+  constructor(private readonly historyService: HistoryService) {}
+
+  //책 히스토리 만들기 = 독서 기록 만들기
+  @Post('/bookshelfbook')
+  async createBookshelfBookHistory(
+    @Req() req: Request, //Guard에서 유저 정보 추출하기
+    @Body() createUserBookHistoryDto: CreateUserBookHistoryDto,
+  ) {
+    try {
+      return {
+        status: 201,
+        response: await this.historyService.createUserBookHistory(
+          1,
+          createUserBookHistoryDto,
+        ),
+      };
+    } catch (e) {
+      return { status: e.HttpStatus, message: e.message };
+    }
+  }
+}

--- a/src/history/history.module.ts
+++ b/src/history/history.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { HistoryController } from './history.controller';
+import { HistoryService } from './history.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
+import { BookshelfBook } from 'src/model/entity/BookshelfBook.entity';
+import { Coin } from 'src/model/entity/Coin.entity';
+import { CoinHistory } from 'src/model/entity/CoinHistory.entity';
+
+@Module({
+  controllers: [HistoryController],
+  providers: [HistoryService],
+  imports: [
+    TypeOrmModule.forFeature([
+      UserBookHistory,
+      BookshelfBook,
+      Coin,
+      CoinHistory,
+    ]),
+  ],
+})
+export class HistoryModule {}

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HistoryService } from './history.service';
+
+describe('HistoryService', () => {
+  let service: HistoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HistoryService],
+    }).compile();
+
+    service = module.get<HistoryService>(HistoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
+import { Repository } from 'typeorm';
+import { CreateUserBookHistoryDto } from './dtos/CreateUserBookHistory.dto';
+import { CoinHistory } from 'src/model/entity/CoinHistory.entity';
+import { Coin } from 'src/model/entity/Coin.entity';
+
+@Injectable()
+export class HistoryService {
+  constructor(
+    @InjectRepository(UserBookHistory)
+    private readonly userBookHistoryRepository: Repository<UserBookHistory>,
+    private readonly coinHistoryRepository: Repository<CoinHistory>,
+    private readonly coinRepository: Repository<Coin>,
+  ) {}
+
+  async createUserBookHistory(
+    userId: number,
+    createUserBookHistoryDto: CreateUserBookHistoryDto,
+  ) {
+    const coinHistoryId = (
+      await this.createCoinHistory(userId, createUserBookHistoryDto)
+    ).coinHistoryId;
+
+    return await this.userBookHistoryRepository.save({
+      userId,
+      ...createUserBookHistoryDto,
+      coinHistoryId,
+    });
+
+    //dto 정보 추출
+    //Coin earning 정보 추가 로직
+    //Coin earning 정보 담아서 userbookhistory 생성
+  }
+
+  async createCoinHistory(
+    userId: number,
+    createUserBookHistoryDto: CreateUserBookHistoryDto,
+  ) {
+    const userCoin = await this.coinRepository.findOneOrFail({
+      where: { userId: userId },
+    }); //유저 코인 객체 찾기
+
+    const newCoinHistory = new CoinHistory();
+    newCoinHistory.coinId = userCoin.coinId;
+    newCoinHistory.earnAmount = createUserBookHistoryDto.coins; //코인 history 엔터티 생성
+
+    userCoin.totalCoin += createUserBookHistoryDto.coins;
+    await this.coinRepository.save(userCoin); //코인 증가
+
+    return await this.coinHistoryRepository.save(newCoinHistory); //history 기록
+  } //내부 코인 생성 처리 함수. userId로 coinId 찾아서 생성 코인 수만큼 생성
+}

--- a/src/model/entity/CoinHistory.entity.ts
+++ b/src/model/entity/CoinHistory.entity.ts
@@ -8,15 +8,15 @@ export class CoinHistory {
   @Column({ name: 'coin_id' })
   coinId: number;
 
-  @Column({ name: 'earn_amount' })
+  @Column({ name: 'earn_amount', default: 0 })
   earnAmount: number;
 
-  @Column({ name: 'spend_amount' })
+  @Column({ name: 'spend_amount', default: 0 }) //값 지정하지 않으면 default 0
   spendAmount: number;
 
-  @Column({ name: 'item_id' })
+  @Column({ name: 'item_id', nullable: true })
   itemId: number;
 
-  @Column({ name: 'reg_date' })
+  @Column({ name: 'reg_date' }) //이건 무슨 칼럼이더라? 생성일자?
   regDate: Date;
 }

--- a/src/model/entity/UserBookHistory.entity.ts
+++ b/src/model/entity/UserBookHistory.entity.ts
@@ -24,4 +24,10 @@ export class UserBookHistory {
 
   @Column({ name: 'end_page', default: 0 })
   endPage: number;
+
+  @Column() //기록되는 독서 시간
+  duration: number;
+
+  @Column({ name: 'coin_history_id' }) //해당 독서로 얻은 코인 습득 정보
+  coinHistoryId: number;
 }


### PR DESCRIPTION
1. 기능 구현 : 독서 기록
코인 습득 및 코인 history 생성 로직을 포함함.

2. 주요 변경 사항
coinHistory entity 수정 : earnAmount, spendAmount default 0로 설정 -> 지정해주지 않으면 0, itemId nullable로 설정
userBookHistory entity 수정 : 책 읽은 시간(duration), coinHistoryId Column 추가


3. 논의할 점
coinHistory entity의 regDate : 등록 일시? 
생성 일시를 개별적으로 엔터티 칼럼으로 관리하기보다는, 
createdAt, deletedAt 칼럼을 포함하는 BasicDate entity를 만들어 기존에 만든 엔터티에서 extends해서 쓰는 게 나을 듯.