### PR TITLE
feat : auth swagger

### DIFF
--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -13,6 +13,7 @@ import {
 import { SaveInBookshelfReqDto } from 'src/book/dto/SaveInBookshelfReq.dto';
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
@@ -27,6 +28,7 @@ import { Request } from 'express';
 @ApiTags('BookService')
 @ApiBadRequestResponse({ description: 'Bad Request' })
 @Controller('book')
+@ApiBearerAuth('accessToken')
 @UseGuards(AuthGuard('access'))
 export class BookController {
   constructor(private readonly bookService: BookService) {} //BookService  주입

--- a/src/history/history.controller.ts
+++ b/src/history/history.controller.ts
@@ -11,6 +11,7 @@ import { HistoryService } from './history.service';
 import { CreateUserBookHistoryDto } from './dtos/CreateUserBookHistory.dto';
 import { Request } from 'express';
 import {
+  ApiBearerAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
@@ -21,6 +22,7 @@ import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('History')
 @Controller('history')
+@ApiBearerAuth('accessToken')
 @UseGuards(AuthGuard('access'))
 export class HistoryController {
   constructor(private readonly historyService: HistoryService) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,16 @@ async function bootstrap() {
     .setTitle('Reafy API')
     .setDescription('Reafy API specification')
     .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'JWT',
+        description: 'Jwt token',
+        in: 'header',
+      },
+      'accessToken',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
accessToken을 입력하여 인증할 수 있게 auth swagger 추가;
`{
  "accessToken" : "카카오 Oauth2 로그인 access Token",
  "vendor" : "kakao"
}`
로 login해서 accessToken 발급받고, api 페이지 상단의 authorize에 입력하여 로그인하면 api 접근 가능