### PR TITLE
책 검색/메모 검색 응답 포맷 수정

### DIFF
--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -19,7 +19,10 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { SearchBookResDto } from './dto/SearchBookRes.dto';
+import {
+  SearchBookResDto,
+  SearchBookResWithPagesDto,
+} from './dto/SearchBookRes.dto';
 import { BookshelfBookDetailDto } from './dto/BookshelfBookDetail.dto';
 import { BookshelfBookDto } from './dto/BookshelfBook.dto';
 import { AuthGuard } from '@nestjs/passport';
@@ -40,8 +43,8 @@ export class BookController {
   })
   @ApiOkResponse({
     description: '검색 결과 출력',
-    type: SearchBookResDto,
-    isArray: true,
+    type: SearchBookResWithPagesDto,
+    isArray: false,
   })
   @Get('/search') // Return : 검색 결과 리스트(10개 단위)
   async searchBook(

--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -39,7 +39,7 @@ export class BookController {
   @ApiOperation({
     summary: '책 검색하기',
     description:
-      '검색어 Query와 Page를 받아 알라딘 APi를 통한 검색 결과를 노출합니다. 페이지는 10개 단위로 주어지며, 응답은 SearchBookResDto의 리스트 형태로 주어집니다.',
+      '검색어 Query와 Page를 받아 알라딘 APi를 통한 검색 결과를 노출합니다. 페이지는 10개 단위로 주어짐. 응답은 SearchBookResWithPages의 형태, item은 SearchBookRes의 Array로 구성.',
   })
   @ApiOkResponse({
     description: '검색 결과 출력',
@@ -48,7 +48,7 @@ export class BookController {
   })
   @Get('/search') // Return : 검색 결과 리스트(10개 단위)
   async searchBook(
-    @Req() req,
+    @Req() req: Request,
     @Query('query') query: string,
     @Query('page') page: number = 1,
   ) {

--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios/dist';
-import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { Inject, Injectable, LoggerService, Search } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { BookshelfBookDto } from 'src/book/dto/BookshelfBook.dto';
 import { RegisterBookDto } from 'src/book/dto/RegisterBook.dto';
@@ -39,6 +39,7 @@ export class BookService {
     const resultArray = await this.httpService.axiosRef.get(
       `https://www.aladin.co.kr/ttb/api/ItemSearch.aspx?ttbkey=${process.env.ALADIN_API_KEY}&Query=${query}&output=js&Cover=Big&Version=20131101&start=${page}`,
     );
+    //query로 들어가는 건 문자열 취급..
     if (resultArray.data.errorCode) {
       this.logger.error(
         '## cannot get book info from aladin api',
@@ -55,15 +56,12 @@ export class BookService {
     //원랜 SearchBookList에 들어간 아이템 수를 세려고 했으나 pending처리 되었기 때문에 0으로 나타났음.
     //컨트롤러 단에서 await하면서 처리되는 것으로 보임.
 
-    const searchBookResWithPages: SearchBookResWithPagesDto = {
-      totalResults: resultArray.data.totalResults,
-      itemPerPage: resultArray.data.item.length,
-      totalPages: Math.ceil(resultArray.data.totalResults / 10),
-      currentPage: resultArray.data.startIndex,
-      item: SearchBookList,
-    };
-
-    return searchBookResWithPages;
+    return SearchBookResWithPagesDto.makeRes(
+      resultArray.data.totalResults,
+      resultArray.data.item.length,
+      Number(page),
+      SearchBookList,
+    );
   }
 
   //내부 책 DB 등록

--- a/src/book/dto/SearchBookRes.dto.ts
+++ b/src/book/dto/SearchBookRes.dto.ts
@@ -32,10 +32,10 @@ export class SearchBookResDto {
 
 export class SearchBookResWithPagesDto {
   @ApiProperty({ description: '해당 검색의 총 결과 수' })
-  totalResults: number;
+  totalItems: number;
 
   @ApiProperty({ description: '현재 페이지의 아이템 수' })
-  itemPerPage: number;
+  currentItems: number;
 
   @ApiProperty({ description: '해당 검색의 총 페이지 수' })
   totalPages: number;
@@ -45,4 +45,20 @@ export class SearchBookResWithPagesDto {
 
   @ApiProperty({ description: '현재 페이지의 아이템 목록' })
   item: SearchBookResDto[];
+
+  static makeRes(
+    totalResults: number,
+    currentResults: number,
+    currentPage: number,
+    item: SearchBookResDto[],
+  ) {
+    const resData: SearchBookResWithPagesDto = {
+      totalItems: totalResults,
+      currentItems: currentResults,
+      totalPages: Math.ceil(totalResults / 10),
+      currentPage: currentPage,
+      item: item,
+    };
+    return resData;
+  }
 }

--- a/src/book/dto/SearchBookRes.dto.ts
+++ b/src/book/dto/SearchBookRes.dto.ts
@@ -29,3 +29,20 @@ export class SearchBookResDto {
     return resData;
   }
 }
+
+export class SearchBookResWithPagesDto {
+  @ApiProperty({ description: '해당 검색의 총 결과 수' })
+  totalResults: number;
+
+  @ApiProperty({ description: '현재 페이지의 아이템 수' })
+  itemPerPage: number;
+
+  @ApiProperty({ description: '해당 검색의 총 페이지 수' })
+  totalPages: number;
+
+  @ApiProperty({ description: '현재 조회한 페이지' })
+  currentPage: number;
+
+  @ApiProperty({ description: '현재 페이지의 아이템 목록' })
+  item: SearchBookResDto[];
+}

--- a/src/memo/dtos/MemoRes.dto.ts
+++ b/src/memo/dtos/MemoRes.dto.ts
@@ -33,7 +33,39 @@ export class MemoResDto {
       createdAt: memoObject.createdAt,
       updatedAt: memoObject.updatedAt,
     };
-    console.log(resData);
     return resData;
   } //각각의 객체에 대해서 파싱하고 Res Dto로 변환
+}
+
+export class MemoResWithPagesDto {
+  @ApiProperty({ description: '해당 검색의 총 결과 수' })
+  totalItems: number;
+
+  @ApiProperty({ description: '현재 페이지의 아이템 수' })
+  currentItems: number;
+
+  @ApiProperty({ description: '해당 검색의 총 페이지 수' })
+  totalPages: number;
+
+  @ApiProperty({ description: '현재 조회한 페이지' })
+  currentPage: number;
+
+  @ApiProperty({ description: '현재 페이지의 아이템 목록' })
+  item: MemoResDto[];
+
+  static makeRes(
+    totalResults: number,
+    currentResults: number,
+    currentPage: number,
+    item: MemoResDto[],
+  ) {
+    const resData: MemoResWithPagesDto = {
+      totalItems: totalResults,
+      currentItems: currentResults,
+      totalPages: Math.ceil(totalResults / 10),
+      currentPage: currentPage,
+      item: item,
+    };
+    return resData;
+  }
 }

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -25,7 +25,7 @@ import {
 } from '@nestjs/swagger';
 import { ApiFile } from 'src/common/decorator/apis.decorator';
 import { UpdateMemoDto } from './dtos/UpdateMemo.dto';
-import { MemoResDto } from './dtos/MemoRes.dto';
+import { MemoResDto, MemoResWithPagesDto } from './dtos/MemoRes.dto';
 
 @ApiTags('Memo')
 @ApiBearerAuth('accessToken')
@@ -43,8 +43,8 @@ export class MemoController {
   @ApiOkResponse({
     description:
       '현재 유저 id로 작성된 모든 메모를 가져옵니다. 크기 10의 pagination. 가장 최근에 작성된 것 부터 반환. 이미지는 서버 주소/imageURL로 접근 가능.',
-    isArray: true,
-    type: MemoResDto,
+    isArray: false,
+    type: MemoResWithPagesDto,
   })
   @Get('')
   async getMemoList(@Req() req: Request, @Query('page') page: number) {
@@ -57,8 +57,8 @@ export class MemoController {
   @ApiOkResponse({
     description:
       'string으로 특정 Hashtag를 Query로 받아, 해당하는 hashtag를 가진 메모를 가져옵니다. 세부 사항은 전체 메모 반환과 동일',
-    isArray: true,
-    type: MemoResDto,
+    isArray: false,
+    type: MemoResWithPagesDto,
   })
   @Get('hashtag')
   async getMemoListByHashtag(
@@ -79,8 +79,8 @@ export class MemoController {
   @ApiOkResponse({
     description:
       'bookshelfBookId를 Query로 받아, 해당 책에 작성된 메모를 가져옵니다. 세부 사항은 동일합니다.',
-    isArray: true,
-    type: MemoResDto,
+    isArray: false,
+    type: MemoResWithPagesDto,
   })
   @Get('bookshelfbook')
   async getMemoListByBookshelfBook(

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -42,7 +42,7 @@ export class MemoController {
   })
   @ApiOkResponse({
     description:
-      '현재 유저 id로 작성된 모든 메모를 가져옵니다. 크기 10의 pagination. 가장 최근에 작성된 것 부터 반환. 이미지는 서버 주소/imageURL로 접근 가능.',
+      '현재 유저 id로 작성된 모든 메모를 가져옵니다. 크기 10의 pagination. 가장 최근에 작성된 것 부터 반환. 이미지는 서버 주소/imageURL로 접근 가능. MemoResWithPagesDto의 형태, item은 MemoResDto의 Array.',
     isArray: false,
     type: MemoResWithPagesDto,
   })

--- a/src/memo/repository/memo-hashtag.repository.ts
+++ b/src/memo/repository/memo-hashtag.repository.ts
@@ -13,7 +13,14 @@ export class MemoHashtagRepository extends Repository<MemoHashtag> {
     hashtagId: number,
     offset: number,
   ) {
-    return await this.query(`
+    const totalResults = await this.query(`
+    SELECT count(*) as total_results
+    FROM (SELECT * FROM(SELECT * FROM memo_hashtag GROUP BY hashtag_id, memo_id) AS subquery WHERE deleted_at IS NULL) as sq
+    LEFT JOIN memo ON sq.memo_id = memo.memo_id
+    WHERE memo.user_id = ${userId} AND sq.hashtag_id = ${hashtagId} AND memo.deleted_at IS NULL;
+    `);
+
+    const resultArray = await this.query(`
     SELECT sq.memo_hashtag_id, memo.user_id, memo.memo_id, memo.bookshelf_book_id, memo.content, memo.page, memo.imageURL, memo.created_at, memo.updated_at
     FROM (SELECT * FROM(SELECT * FROM memo_hashtag GROUP BY hashtag_id, memo_id) AS subquery WHERE deleted_at IS NULL) as sq
     LEFT JOIN memo ON sq.memo_id = memo.memo_id
@@ -21,9 +28,12 @@ export class MemoHashtagRepository extends Repository<MemoHashtag> {
     ORDER BY memo.created_at DESC
     LIMIT 10 OFFSET ${offset};
     `);
+
+    const resultObject = { totalResults, resultArray };
+    return resultObject;
     /*해시태그 ID를 통해 메모-해시태그와 메모 테이블 join하여 해당하는 메모 검색. FROM 절의 subquery를 이중으로 사용함. 
       첫 번째 subquery는 GROUP BY를 통해 해시태그 id - 메모 id 쌍에 대한 중복 제거,
-      두 번째 subquery(sq)는 subquery에 대하여 softDelete된 엔트리들을 제거해줌 -> ORM 이용했으면 더 편했을 듯 */
+      두 번째 subquery(sq)는 subquery에 대하여 softDelete된 엔트리들을 제거해줌 -> ORM 이용했으면 더 편했을 듯.. 근데 쿼리가 너무 너무 너무 복잡 */
   }
 
   async getHashtagsByMemoId(memoId: number) {

--- a/src/memo/repository/memo.repository.ts
+++ b/src/memo/repository/memo.repository.ts
@@ -8,12 +8,24 @@ export class MemoRepository extends Repository<Memo> {
     super(Memo, dataSource.createEntityManager());
   }
   async getMemoListById(userId: number, page: number) {
-    return await this.find({
+    const totalResults = await this.count({ where: { userId } });
+    const resultArray = await this.find({
       where: { userId },
       order: { createdAt: 'DESC' },
       take: 10,
       skip: (page - 1) * 10,
     });
+
+    const resultObject = { totalResults, resultArray };
+
+    return resultObject;
+
+    // return await this.find({
+    //   where: { userId },
+    //   order: { createdAt: 'DESC' },
+    //   take: 10,
+    //   skip: (page - 1) * 10,
+    // });
   }
 
   async getMemoListByBookshelfBookId(
@@ -21,13 +33,19 @@ export class MemoRepository extends Repository<Memo> {
     bookshelfBookId: number,
     offset: number,
   ) {
-    return await this.query(`
-  SELECT * 
-  FROM memo
-  WHERE memo.bookshelf_book_id = ${bookshelfBookId} AND memo.user_id = ${userId} AND memo.deleted_at IS NULL
-  ORDER BY memo.created_at DESC
-  LIMIT 10 OFFSET ${offset};
-  `);
+    const totalResults = await this.count({
+      where: { bookshelfBookId: bookshelfBookId, userId: userId },
+    });
+    const resultArray = await this.query(`
+    SELECT * 
+    FROM memo
+    WHERE memo.bookshelf_book_id = ${bookshelfBookId} AND memo.user_id = ${userId} AND memo.deleted_at IS NULL
+    ORDER BY memo.created_at DESC
+    LIMIT 10 OFFSET ${offset};
+    `);
+    const resultObject = { totalResults, resultArray };
+
+    return resultObject;
   }
   //Soft Delete 체크.
 }


### PR DESCRIPTION
/book/search
/memo
/memo/hashtag
/memo/bookshelfbook의 Response가 
전체 검색 결과 수/현재 노출된 검색 결과 수/전체 페이지/현재 페이지를 포함하도록 수정.

(수정 전)
![res-preupdate](https://github.com/DevKor-github/reafy-back/assets/109478362/4cbb3f54-d012-4d28-9929-58514c3128fa)

(수정 후)
![res-postupdate](https://github.com/DevKor-github/reafy-back/assets/109478362/488a0120-e9f9-4f8a-b57c-c845906cf0ac)

위 엔드포인트의 응답을 사용하던 곳에서는 .item을 추가하여야 정상적으로 작동할 것으로 보임