### PR TITLE
built-in exception 분기 처리

### DIFF
--- a/src/common/exception/base.exception.ts
+++ b/src/common/exception/base.exception.ts
@@ -1,6 +1,6 @@
-import { ErrorCode, INTERNAL_SERVER_ERROR } from './error-code/error.code';
+import { ErrorCode, ErrorCodeEnum, INTERNAL_SERVER_ERROR } from './error-code/error.code';
 
-export class BaseException extends Error { 
+export class BaseException extends Error {
   readonly errorCode: ErrorCode;
 
   constructor(errorCode: ErrorCode, message?: string) {
@@ -18,4 +18,11 @@ export class BaseException extends Error {
 // filter에서 뿐만 아니라 다른 service에서도 해당 함수를 사용할 수 있게 이름 변경
 export function InternalServerException(message?: string): BaseException {
   return new BaseException(INTERNAL_SERVER_ERROR, message);
+}
+
+export function UndefinedException(status?: number, message?: string): BaseException {
+  const undefinedException: ErrorCode = {
+    status, message, errorCode: ErrorCodeEnum.UNDEFINED_EXCEPTION
+  }
+  return new BaseException(undefinedException);
 }

--- a/src/common/exception/error-code/error.code.ts
+++ b/src/common/exception/error-code/error.code.ts
@@ -36,6 +36,7 @@ export enum ErrorCodeEnum {
   HASHTAG_NOT_FOUND = '0302',
   HISTORY_NOT_FOUND = '0401',
   NOT_ENOUGH_COIN = '0501',
+  UNDEFINED_EXCEPTION = '9999',
 }
 
 export const INTERNAL_SERVER_ERROR = new ErrorCodeObject(

--- a/src/common/filter/custom-exception.filter.ts
+++ b/src/common/filter/custom-exception.filter.ts
@@ -1,5 +1,6 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { UnauthorizedUserException } from '../exception/authentication.exception';
 import {
   BaseException,
   InternalServerException,
@@ -13,11 +14,15 @@ export class CustomExceptionFilter implements ExceptionFilter {
     if (exception instanceof BaseException) {
       customException = exception;
     } else if (exception instanceof HttpException) { // built-in exception 대응
-      customException = UndefinedException(exception?.getStatus(), JSON.stringify(exception?.getResponse()));
+      switch (exception?.getStatus()) {
+        case 401: customException = UnauthorizedUserException();
+        default: customException = UndefinedException(exception?.getStatus(), JSON.stringify(exception?.getResponse()));
+
+      }
     } else {
       customException = InternalServerException();
     }
-    
+
     const ctx = host.switchToHttp();
     const request = ctx.getRequest<Request>();
     const response = ctx.getResponse<Response>();

--- a/src/common/filter/custom-exception.filter.ts
+++ b/src/common/filter/custom-exception.filter.ts
@@ -15,9 +15,12 @@ export class CustomExceptionFilter implements ExceptionFilter {
       customException = exception;
     } else if (exception instanceof HttpException) { // built-in exception 대응
       switch (exception?.getStatus()) {
-        case 401: customException = UnauthorizedUserException();
-        default: customException = UndefinedException(exception?.getStatus(), JSON.stringify(exception?.getResponse()));
-
+        case 401: 
+          customException = UnauthorizedUserException();
+          break;
+        default: 
+          customException = UndefinedException(exception?.getStatus(), JSON.stringify(exception?.getResponse()));
+          break;
       }
     } else {
       customException = InternalServerException();


### PR DESCRIPTION
passport를 사용하여 인증을 처리하는 경우 passport 자체적으로 built-in exception인 HttpException을 thorw한다.
이를 대응하기 위하여 custom exception filter에서 custom-exception이 아닌 경우 분기 처리를 하도록 변경하였고 이때 status는 HttpException의 status, message는 HttpException의 response를 보내도록 처리하였다. 또한 이렇게 미리 정의하지 못한 에러의 경우 errorCode = 9999로 정의하였다.

인증 시에 passport를 의존하지 않게 고치는 방향도 존재하지만 추후 passport와 같이 외부 라이브러리를 사용하거나, unchecked exception이 발생하는 경우와 같이 모든 exception을 대응하기는 어렵기에 built-in exception이 발생하는 경우 custom exception filter에서 대응하는게 조금 더 합리적이라고 생각해서 해당 부분을 수정하는 방향으로 개선하였다.

분기 처리하는 부분이 살짝 아쉬운거 같아서 해당 부분의 개선이 되면 더 좋을같긴하다...