### PR TITLE
독서기록이 없는 경우 대응

### DIFF
--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -43,12 +43,12 @@ export class HistoryService {
       where: { userId: userId, bookshelfBookId: bookshelfBookId },
       order: { createdAt: 'DESC' },
     });
-    if (resultArray.length == 0) {
-      this.logger.error(
-        `## can not find book history userId : ${userId}, bookshelfBookId : ${bookshelfBookId}`,
-      );
-      throw HistoryNotFound();
-    }
+    // if (resultArray.length == 0) {
+    //   this.logger.error(
+    //     `## can not find book history userId : ${userId}, bookshelfBookId : ${bookshelfBookId}`,
+    //   );
+    //   throw HistoryNotFound();
+    // }
     return this.processHistoryList(resultArray);
   }
 


### PR DESCRIPTION
독서 기록이 없는 경우 404가 아니라 빈 리스트로 던지게 수정


일단 간단하게 에러 던지는 곳에 주석처리만 했는데 다른 방식으로 해야할까?