### PR TITLE
퀘스트 기능 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { ItemModule } from './item/item.module';
 import { MemoModule } from './memo/memo.module';
 import { StatisticsModule } from './statistics/statistics.module';
 import { UserModule } from './user/user.module';
+import { QuestModule } from './quest/quest.module';
 
 @Module({
   imports: [
@@ -59,6 +60,7 @@ import { UserModule } from './user/user.module';
     MemoModule,
     StatisticsModule,
     CoinModule,
+    QuestModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/exception/error-code/error.code.ts
+++ b/src/common/exception/error-code/error.code.ts
@@ -37,6 +37,7 @@ export enum ErrorCodeEnum {
   HISTORY_NOT_FOUND = '0401',
   NOT_ENOUGH_COIN = '0501',
   INVALID_DATE_FORMAT = '0601',
+  INVALID_QUEST_ID = '0701',
   UNDEFINED_EXCEPTION = '9999',
 }
 
@@ -142,3 +143,9 @@ export const INVALID_DATE_FORMAT = new ErrorCodeObject(
   ErrorCodeEnum.INVALID_DATE_FORMAT,
 ); //0501
 
+//StatisticsService ErrorCode - 06
+export const INVALID_QUEST_ID = new ErrorCodeObject(
+  HttpStatus.BAD_REQUEST,
+  'Request Id is not exist',
+  ErrorCodeEnum.INVALID_DATE_FORMAT,
+); //0501

--- a/src/common/exception/quest-service.exception.ts
+++ b/src/common/exception/quest-service.exception.ts
@@ -1,0 +1,6 @@
+import { BaseException } from './base.exception';
+import { INVALID_QUEST_ID } from './error-code/error.code';
+
+export function InvalidQuestId(message?: string): BaseException {
+  return new BaseException(INVALID_QUEST_ID, message);
+}

--- a/src/common/util/date.util.ts
+++ b/src/common/util/date.util.ts
@@ -1,0 +1,18 @@
+import { InvalidDateFormatException } from '../exception/statistics-service.exception';
+
+export class DateUtilService {
+  static checkDateFormatYYYYMMDD(dateString: string) {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+    if (!dateRegex.test(dateString)) {
+      throw InvalidDateFormatException(
+        'Invalid date format. Date should be in YYYY-MM-DD format.',
+      );
+    }
+  }
+
+  static getDateYYYYMMDD(dateString: string): Date {
+    this.checkDateFormatYYYYMMDD(dateString);
+    return new Date(dateString + 'T00:00:00Z');
+  }
+}

--- a/src/model/entity/Quest.entity.ts
+++ b/src/model/entity/Quest.entity.ts
@@ -1,0 +1,40 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BasicDate } from './BasicDate.entity';
+
+export enum QuestType {
+  PERIOD = 'P', //주기성 퀘스트
+  TEMP = 'T', // 1회성 퀘스트
+}
+
+@Entity('quest')
+export class Quest extends BasicDate {
+  @PrimaryGeneratedColumn({ name: 'quest_id' })
+  questId: number;
+
+  @Column({ name: 'type', comment: 'P: 주기성 퀘스트, T: 1회성 퀘스트' })
+  type: QuestType;
+
+  @Column({ name: 'description' })
+  description: string;
+
+  @Column({ name: 'coin' })
+  coin: number;
+
+  @Column({ name: 'period' })
+  period: number;
+
+  static newEntity(
+    type: QuestType,
+    description: string,
+    coin: number,
+    period: number,
+  ) {
+    const quest: Quest = new Quest();
+    quest.type = type;
+    quest.description = description;
+    quest.coin = coin;
+    quest.period = period;
+
+    return quest;
+  }
+}

--- a/src/model/entity/QuestHistory.entity.ts
+++ b/src/model/entity/QuestHistory.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BasicDate } from './BasicDate.entity';
+
+@Entity('quest_history')
+export class QuestHistory extends BasicDate {
+  @PrimaryGeneratedColumn({ name: 'quest_history_id' })
+  questHistoryId: number;
+
+  @Column({ name: 'user_id' })
+  userId: number;
+
+  @Column({ name: 'quest_id' })
+  questId: number;
+
+  static newEntity(userId: number, questId: number) {
+    const questHistory: QuestHistory = new QuestHistory();
+    questHistory.userId = userId;
+    questHistory.questId = questId;
+    return questHistory;
+  }
+}

--- a/src/quest/dtos/quest.dto.ts
+++ b/src/quest/dtos/quest.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Quest, QuestType } from '../../model/entity/Quest.entity';
+import { QuestHistory } from '../../model/entity/QuestHistory.entity';
+
+export class QuestDto {
+  @ApiProperty({ description: '퀘스트 id' })
+  questId: number;
+
+  @ApiProperty({ description: '퀘스트 타입' })
+  type: QuestType;
+
+  @ApiProperty({ description: '퀘스트 설명' })
+  description: string;
+
+  @ApiProperty({ description: '퀘스트 획득 coin' })
+  coin: number;
+
+  @ApiProperty({ description: '퀘스트 반복 주기' })
+  period: number;
+
+  static makeRes(questEntity: Quest) {
+    const resData = new QuestDto();
+    resData.questId = questEntity.questId;
+    resData.type = questEntity.type;
+    resData.description = questEntity.description;
+    resData.coin = questEntity.coin;
+    resData.period = questEntity.period;
+    return resData;
+  }
+}
+
+export class QuestListDto {
+  @ApiProperty({ description: '퀘스트 리스트' })
+  questList: QuestDto[];
+  static makeRes(questEntityList: Quest[]) {
+    const resData = new QuestListDto();
+    resData.questList = questEntityList.map(QuestDto.makeRes);
+    return resData;
+  }
+}
+
+export class QuestHistoryDto {
+  @ApiProperty({ description: '퀘스트 히스토리 id' })
+  questHistoryId: number;
+
+  @ApiProperty({ description: '퀘스트 id' })
+  questId: number;
+
+  @ApiProperty({ description: '달성 시각' })
+  createdAt: Date;
+
+  static makeRes(questHistory: QuestHistory) {
+    const resData = new QuestHistoryDto();
+    resData.questHistoryId = questHistory.questHistoryId;
+    resData.questId = questHistory.questId;
+    resData.createdAt = questHistory.createdAt;
+    return resData;
+  }
+}
+
+export class QuestHistoryListDto {
+  @ApiProperty({ description: '퀘스트 히스토리 리스트' })
+  questHistoryList: QuestHistoryDto[];
+
+  static makeRes(questHistoryEntityList: QuestHistory[]) {
+    const resData = new QuestHistoryListDto();
+    resData.questHistoryList = questHistoryEntityList.map(
+      QuestHistoryDto.makeRes,
+    );
+    return resData;
+  }
+}

--- a/src/quest/quest.controller.spec.ts
+++ b/src/quest/quest.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestController } from './quest.controller';
+
+describe('QuestController', () => {
+  let controller: QuestController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuestController],
+    }).compile();
+
+    controller = module.get<QuestController>(QuestController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/quest/quest.controller.ts
+++ b/src/quest/quest.controller.ts
@@ -1,0 +1,97 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
+  QuestHistoryDto,
+  QuestHistoryListDto,
+  QuestListDto,
+} from './dtos/quest.dto';
+import { QuestService } from './quest.service';
+import { AuthGuard } from '@nestjs/passport';
+import { QuestType } from '../model/entity/Quest.entity';
+import { DateUtilService } from '../common/util/date.util';
+
+@ApiTags('Quest')
+@ApiBearerAuth('accessToken')
+@Controller('quest')
+@UseGuards(AuthGuard('access'))
+export class QuestController {
+  constructor(private readonly questService: QuestService) {}
+
+  @ApiOperation({
+    summary: '기본 퀘스트 생성',
+    description: '주간 독서 기록에 대한 퀘스트를 만들기 위한 api',
+  })
+  @ApiOkResponse({
+    description: '생성된 퀘스트 리스트 반환',
+    isArray: true,
+    type: QuestListDto,
+  })
+  @Post('/default')
+  async saveDefaultQuest(): Promise<QuestListDto> {
+    return this.questService.createDefaultQuest();
+  }
+
+  @ApiOperation({
+    summary: '퀘스트 리스트 가져오기',
+    description: '주어진 타입에 맞는 모든 퀘스트 리스트 가져오기',
+  })
+  @ApiOkResponse({
+    description: '주어진 타입에 맞는 퀘스트 리스트를 반환',
+    isArray: true,
+    type: QuestListDto,
+  })
+  @Get('/list')
+  async getQuestList(@Query('type') type: QuestType): Promise<QuestListDto> {
+    return this.questService.getQuestList(type);
+  }
+
+  @ApiOperation({
+    summary: '퀘스트 달성 처리',
+    description: '퀘스트 id 기준으로 퀘스트를 달성 처리한다.',
+  })
+  @ApiOkResponse({
+    description: '달성된 퀘스트에 대한 기록이 반환된다.',
+    isArray: false,
+    type: QuestHistoryDto,
+  })
+  @Post('/achieve/:questId')
+  async achieveQuest(
+    @Req() req,
+    @Param('questId') questId: number,
+  ): Promise<QuestHistoryDto> {
+    const userId = req.user.userId;
+    return this.questService.achieveQuest(userId, questId);
+  }
+
+  @ApiOperation({
+    summary: '주간 달성한 퀘스트 리스트 가져오기',
+    description: '오늘 날짜 기준으로 금주에 달성된 퀘스트 리스트를 가져온다. ',
+  })
+  @ApiOkResponse({
+    description: '주간 달성된 퀘스트 리스트가 반환된다.',
+    isArray: true,
+    type: QuestHistoryListDto,
+  })
+  @Get('/weekly/achieve')
+  async achieveWeeklyQuest(
+    @Req() req,
+    @Query('date') dateString: string,
+  ): Promise<QuestHistoryListDto> {
+    const userId = req.user.userId;
+    const date = DateUtilService.getDateYYYYMMDD(dateString);
+    return await this.questService.getWeeklyAchieveQuestList(userId, date);
+  }
+}

--- a/src/quest/quest.module.ts
+++ b/src/quest/quest.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { QuestController } from './quest.controller';
+import { QuestService } from './quest.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CoinModule } from '../coin/coin.module';
+import { Quest } from '../model/entity/Quest.entity';
+import { QuestHistory } from '../model/entity/QuestHistory.entity';
+import { QuestRepository } from './repository/quest.repository';
+import { QuestHistoryRepository } from './repository/quest-history.repository';
+
+@Module({
+  controllers: [QuestController],
+  providers: [QuestService, QuestRepository, QuestHistoryRepository],
+  imports: [CoinModule, TypeOrmModule.forFeature([Quest, QuestHistory])],
+})
+export class QuestModule {}

--- a/src/quest/quest.service.spec.ts
+++ b/src/quest/quest.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestService } from './quest.service';
+
+describe('QuestService', () => {
+  let service: QuestService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuestService],
+    }).compile();
+
+    service = module.get<QuestService>(QuestService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/quest/quest.service.ts
+++ b/src/quest/quest.service.ts
@@ -1,0 +1,96 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  LoggerService,
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { QuestRepository } from './repository/quest.repository';
+import { QuestHistoryRepository } from './repository/quest-history.repository';
+import {
+  QuestDto,
+  QuestHistoryDto,
+  QuestHistoryListDto,
+  QuestListDto,
+} from './dtos/quest.dto';
+import { Quest, QuestType } from '../model/entity/Quest.entity';
+import { QuestHistory } from '../model/entity/QuestHistory.entity';
+import { CoinService } from '../coin/coin.service';
+import { Between } from 'typeorm';
+import { InvalidQuestId } from '../common/exception/quest-service.exception';
+
+@Injectable()
+export class QuestService {
+  constructor(
+    private readonly questRepository: QuestRepository,
+    private readonly questHistoryRepository: QuestHistoryRepository,
+    private readonly coinService: CoinService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+  ) {}
+
+  async createQuest(questDto: QuestDto): Promise<QuestDto> {
+    const questEntity: Quest = Quest.newEntity(
+      questDto.type,
+      questDto.description,
+      questDto.coin,
+      questDto.period,
+    );
+    const savedQuest = await this.questRepository.save(questEntity);
+    return QuestDto.makeRes(savedQuest);
+  }
+
+  async createDefaultQuest(): Promise<QuestListDto> {
+    const questEntityList: Quest[] = [];
+    questEntityList.push(
+      Quest.newEntity(QuestType.PERIOD, '주 당 누적 독서 5시간', 5, 7),
+      Quest.newEntity(QuestType.PERIOD, '주 당 누적 독서 10시간', 10, 7),
+      Quest.newEntity(QuestType.PERIOD, '주 당 누적 독서 15시간', 15, 7),
+      Quest.newEntity(QuestType.PERIOD, '주 당 누적 독서 20시간', 20, 7),
+    );
+    const savedQuestList = await this.questRepository.save(questEntityList);
+    return QuestListDto.makeRes(savedQuestList);
+  }
+
+  async getQuestList(type: QuestType): Promise<QuestListDto> {
+    const questEntityList: Quest[] = await this.questRepository.find({
+      where: { type: type },
+    });
+    return QuestListDto.makeRes(questEntityList);
+  }
+
+  async achieveQuest(
+    userId: number,
+    questId: number,
+  ): Promise<QuestHistoryDto> {
+    const questHistoryEntity: QuestHistory = QuestHistory.newEntity(
+      userId,
+      questId,
+    );
+    const quest = await this.questRepository.findOne({
+      where: { questId: questId },
+    });
+    if (!quest) throw InvalidQuestId();
+
+    const savedHistory =
+      await this.questHistoryRepository.save(questHistoryEntity);
+    await this.coinService.addCoin(userId, quest.coin);
+    return QuestHistoryDto.makeRes(savedHistory);
+  }
+
+  async getWeeklyAchieveQuestList(
+    userId: number,
+    date: Date,
+  ): Promise<QuestHistoryListDto> {
+    const startDate = new Date(date);
+    startDate.setDate(date.getDate() - date.getDay()); // 금주의 독서 기록을 가져오기 위하여 현재 날짜 기준 금주의 시작 날짜 가져옴
+
+    const lastDate = new Date(startDate);
+    lastDate.setDate(startDate.getDate() + 6);
+
+    const questHistoryList = await this.questHistoryRepository.find({
+      where: { userId: userId, createdAt: Between(startDate, lastDate) },
+    });
+    return QuestHistoryListDto.makeRes(questHistoryList);
+  }
+}

--- a/src/quest/repository/quest-history.repository.ts
+++ b/src/quest/repository/quest-history.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { QuestHistory } from '../../model/entity/QuestHistory.entity';
+
+@Injectable()
+export class QuestHistoryRepository extends Repository<QuestHistory> {
+  constructor(private readonly dataSource: DataSource) {
+    super(QuestHistory, dataSource.createEntityManager());
+  }
+}

--- a/src/quest/repository/quest.repository.ts
+++ b/src/quest/repository/quest.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Quest } from '../../model/entity/Quest.entity';
+
+@Injectable()
+export class QuestRepository extends Repository<Quest> {
+  constructor(private readonly dataSource: DataSource) {
+    super(Quest, dataSource.createEntityManager());
+  }
+}

--- a/src/statistics/statistics.controller.ts
+++ b/src/statistics/statistics.controller.ts
@@ -13,13 +13,14 @@ import {
   TodayStatisticsDto,
 } from './dtos/Statistics.dto';
 import { StatisticsService } from './statistics.service';
+import { DateUtilService } from '../common/util/date.util';
 
 @ApiTags('Statistics')
 @ApiBearerAuth('accessToken')
 @UseGuards(AuthGuard('access'))
 @Controller('statistics')
 export class StatisticsController {
-  constructor(private readonly statisticsService: StatisticsService) { }
+  constructor(private readonly statisticsService: StatisticsService) {}
 
   @ApiOperation({ summary: '월별 읽은 페이지 수' })
   @ApiOkResponse({
@@ -54,7 +55,6 @@ export class StatisticsController {
     );
   }
 
-
   @ApiOperation({ summary: '주별 총 독서 시간' })
   @ApiOkResponse({
     description:
@@ -67,7 +67,7 @@ export class StatisticsController {
     @Req() req: Request,
     @Query('date') dateString: string,
   ) {
-    const date = this.statisticsService.getDateYYYYMMDD(dateString);
+    const date = DateUtilService.getDateYYYYMMDD(dateString);
 
     return await this.statisticsService.getWeeklyTotalReadingTimes(
       req.user.userId,

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -9,7 +9,6 @@ import {
   TodayStatisticsDto,
   WeeklyTotalReadingTimesDto,
 } from './dtos/Statistics.dto';
-import { InvalidDateFormatException } from 'src/common/exception/statistics-service.exception';
 
 @Injectable()
 export class StatisticsService {
@@ -17,7 +16,7 @@ export class StatisticsService {
     private readonly userBookHistoryRepository: UserBookHistoryRepository,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
-  ) { }
+  ) {}
 
   async getMonthlyTotalPages(
     userId: number,
@@ -59,19 +58,6 @@ export class StatisticsService {
     return monthlyTotalReadingTimesList;
   }
 
-  checkDateFormatYYYYMMDD(dateString : string) {
-    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-
-    if (!dateRegex.test(dateString)) {
-      throw InvalidDateFormatException('Invalid date format. Date should be in YYYY-MM-DD format.');
-    }
-  }
-
-  getDateYYYYMMDD(dateString : string) : Date{
-    this.checkDateFormatYYYYMMDD(dateString);    
-    return new Date(dateString + 'T00:00:00Z');
-  }
-
   async getWeeklyTotalReadingTimes(
     userId: number,
     date: Date,
@@ -85,16 +71,18 @@ export class StatisticsService {
     let totalReadingTime = 0;
 
     const resultArray = await this.userBookHistoryRepository.find({
-      where: { userId: userId, createdAt: Between(startDate, lastDate) }
+      where: { userId: userId, createdAt: Between(startDate, lastDate) },
     });
 
     resultArray.forEach((userBookHistory: UserBookHistory) => {
       totalReadingTime += userBookHistory.duration;
-    })
-    const weeklyTotalReadingTimesDto = new WeeklyTotalReadingTimesDto(date, totalReadingTime);
+    });
+    const weeklyTotalReadingTimesDto = new WeeklyTotalReadingTimesDto(
+      date,
+      totalReadingTime,
+    );
     return weeklyTotalReadingTimesDto;
   }
-
 
   async getTodayStatistics(userId: number): Promise<TodayStatisticsDto> {
     const queryPacket =


### PR DESCRIPTION
## Description
퀘스트 기능 추가
- 기본 퀘스트 추가 api
- 현재 존재하는 퀘스트 리스트 가져오는 api (type에 따라)
- 퀘스트 달성 처리
    - 퀘스트에 할당된 코인 추가 기능
- 금주에 달성된 퀘스트 리스트 조회 기능
- 날짜 유틸 클래스 생성 

## To Discuss
추후 퀘스트의 추가 가능성을 위하여 우선 quest entity에 type을 추가했는데 추후 quest_group 과 같은 entity를 추가하여 관리하는 것이 좋을 것 같음
우선 추가 가능성이 없다고 생각해서 quest entity 하나만 생성

퀘스트 달성 시 코인 획득하는 로직을 프론트보다는 백엔드에서 처리하는게 좋을 것 같아서 퀘스트 달성 api 만 사용하면 자동으로 퀘스트에 할당된 코인을 획득하도록 작업

## Test
- 

## ETC
- 

## Related Issues
- 