### PR TITLE
Feature/reading log response - 커서 기반 페이지네이션

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
+        "date-fns": "^3.6.0",
+        "date-fns-tz": "^3.1.3",
         "docker": "^1.0.0",
         "install": "^0.13.0",
         "multer-s3": "^3.0.1",
@@ -1594,9 +1596,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -5886,18 +5888,20 @@
       "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.1.3.tgz",
+      "integrity": "sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0"
       }
     },
     "node_modules/debug": {
@@ -14547,9 +14551,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -17260,6 +17264,21 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/typeorm/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/typeorm/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
+    "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.1.3",
     "docker": "^1.0.0",
     "install": "^0.13.0",
     "multer-s3": "^3.0.1",

--- a/src/common/constant/history.constant.ts
+++ b/src/common/constant/history.constant.ts
@@ -1,0 +1,1 @@
+export const HISTORY_LIST_TAKE = 10;

--- a/src/history/dtos/UserBookHistoryRes.dto.ts
+++ b/src/history/dtos/UserBookHistoryRes.dto.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber } from 'class-validator';
 import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
@@ -20,6 +22,9 @@ export class UserBookHistoryResDto {
   @IsNumber()
   endPage: number;
 
+  @ApiProperty({ description: '독서 기록 생성일' })
+  createdAt: string;
+
   @ApiProperty({ description: '독서 시간(초 단위)' })
   @IsNumber()
   duration: number;
@@ -31,6 +36,7 @@ export class UserBookHistoryResDto {
     resData.startPage = data.startPage;
     resData.endPage = data.endPage;
     resData.duration = data.duration;
+    resData.createdAt = format(data.createdAt, 'aaaa h시 m분', { locale: ko });
 
     return resData;
   }

--- a/src/history/dtos/paginated-user-book-history-res.dto.ts
+++ b/src/history/dtos/paginated-user-book-history-res.dto.ts
@@ -2,10 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { UserBookHistoryResDto } from './UserBookHistoryRes.dto';
 
 class PaginatedUserBookHistoryMeta {
-  @ApiProperty()
+  @ApiProperty({ description: '마지막 레코드 커서 id' })
   cursorId: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: '다음 페이지 존재 여부' })
   hasNextData: boolean;
 
   constructor(cursorId: number, hasNextData: boolean) {
@@ -15,10 +15,10 @@ class PaginatedUserBookHistoryMeta {
 }
 
 export class PaginatedUserBookHistoryRes {
-  @ApiProperty({ type: Object })
+  @ApiProperty({ type: Object, description: '유저 독서 기록 목록' })
   data: Record<string, UserBookHistoryResDto[]>;
 
-  @ApiProperty()
+  @ApiProperty({ description: '유저 독서 기록 메타 정보' })
   meta: PaginatedUserBookHistoryMeta;
 
   constructor(

--- a/src/history/dtos/paginated-user-book-history-res.dto.ts
+++ b/src/history/dtos/paginated-user-book-history-res.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserBookHistoryResDto } from './UserBookHistoryRes.dto';
+
+class PaginatedUserBookHistoryMeta {
+  @ApiProperty()
+  cursorId: number;
+
+  @ApiProperty()
+  hasNextData: boolean;
+
+  constructor(cursorId: number, hasNextData: boolean) {
+    this.cursorId = cursorId;
+    this.hasNextData = hasNextData;
+  }
+}
+
+export class PaginatedUserBookHistoryRes {
+  @ApiProperty({ type: Object })
+  data: Record<string, UserBookHistoryResDto[]>;
+
+  @ApiProperty()
+  meta: PaginatedUserBookHistoryMeta;
+
+  constructor(
+    userBookHistoryList: Record<string, UserBookHistoryResDto[]>,
+    cursorId: number,
+    hasNextData: boolean,
+  ) {
+    this.data = userBookHistoryList;
+    this.meta = new PaginatedUserBookHistoryMeta(cursorId, hasNextData);
+  }
+}

--- a/src/history/dtos/user-book-history-req.dto.ts
+++ b/src/history/dtos/user-book-history-req.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UserBookHistoryReqDto {
-  @ApiProperty({ required: false })
+  @ApiProperty({ description: '책장 id', required: false })
   bookshelfBookId: number;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ description: '커서 id', required: false })
   cursorId: number;
 }

--- a/src/history/dtos/user-book-history-req.dto.ts
+++ b/src/history/dtos/user-book-history-req.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserBookHistoryReqDto {
+  @ApiProperty({ required: false })
+  bookshelfBookId: number;
+
+  @ApiProperty({ required: false })
+  cursorId: number;
+}

--- a/src/history/history.controller.ts
+++ b/src/history/history.controller.ts
@@ -21,6 +21,8 @@ import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
 import { CreateUserBookHistoryDto } from './dtos/CreateUserBookHistory.dto';
 import { HistoryService } from './history.service';
 import { UserBookHistoryReqDto } from './dtos/user-book-history-req.dto';
+import { UserBookHistoryResDto } from './dtos/UserBookHistoryRes.dto';
+import { PaginatedUserBookHistoryRes } from './dtos/paginated-user-book-history-res.dto';
 
 @ApiTags('History')
 @Controller('history')
@@ -36,8 +38,7 @@ export class HistoryController {
   })
   @ApiOkResponse({
     description: '현재 유저의 독서 기록 목록',
-    type: UserBookHistory,
-    isArray: true,
+    type: PaginatedUserBookHistoryRes,
   })
   @Get('')
   async getBookshelfBookHistory(
@@ -56,7 +57,7 @@ export class HistoryController {
   })
   @ApiOkResponse({
     description: '현재 유저의 최근 독서 기록',
-    type: UserBookHistory,
+    type: UserBookHistoryResDto,
   })
   @Get('/recently')
   async getRecentBookshelfBookHistory(

--- a/src/history/history.controller.ts
+++ b/src/history/history.controller.ts
@@ -39,11 +39,6 @@ export class HistoryController {
     type: UserBookHistory,
     isArray: true,
   })
-  @ApiQuery({
-    name: 'bookshelfbookid',
-    required: false,
-    description: '검색할 bookshelfBookId',
-  })
   @Get('')
   async getBookshelfBookHistory(
     @Req() req: Request,
@@ -63,22 +58,15 @@ export class HistoryController {
     description: '현재 유저의 최근 독서 기록',
     type: UserBookHistory,
   })
-  @ApiQuery({
-    name: 'bookshelfbookid',
-    required: true,
-    description: '검색할 bookshelfBookId',
-  })
   @Get('/recently')
   async getRecentBookshelfBookHistory(
     @Req() req: Request,
-    @Query('bookshelfbookid') bookshelfBookId: string,
+    @Query() userBookHistoryReqDto: UserBookHistoryReqDto,
   ) {
-    const userBookHistoryResDtoList =
-      await this.historyService.getUserBookHistoryByBookshelfBook(
-        req.user.userId,
-        Number(bookshelfBookId),
-      );
-    return userBookHistoryResDtoList[0];
+    return await this.historyService.getRecentUserBookHistory(
+      req.user.userId,
+      userBookHistoryReqDto,
+    );
   }
 
   //책 히스토리 만들기 = 독서 기록 만들기

--- a/src/history/history.controller.ts
+++ b/src/history/history.controller.ts
@@ -20,6 +20,7 @@ import { Request } from 'express';
 import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
 import { CreateUserBookHistoryDto } from './dtos/CreateUserBookHistory.dto';
 import { HistoryService } from './history.service';
+import { UserBookHistoryReqDto } from './dtos/user-book-history-req.dto';
 
 @ApiTags('History')
 @Controller('history')
@@ -46,14 +47,12 @@ export class HistoryController {
   @Get('')
   async getBookshelfBookHistory(
     @Req() req: Request,
-    @Query('bookshelfbookid') bookshelfBookId: string,
+    @Query() userBookHistoryReqDto: UserBookHistoryReqDto,
   ) {
-    if (bookshelfBookId)
-      return await this.historyService.getUserBookHistoryByBookshelfBook(
-        req.user.userId,
-        Number(bookshelfBookId),
-      );
-    return await this.historyService.getUserBookHistory(req.user.userId);
+    return await this.historyService.getUserBookHistory(
+      req.user.userId,
+      userBookHistoryReqDto,
+    );
   }
 
   @ApiOperation({

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -8,6 +8,7 @@ import { CreateUserBookHistoryDto } from './dtos/CreateUserBookHistory.dto';
 import { UserBookHistoryResDto } from './dtos/UserBookHistoryRes.dto';
 import { UserBookHistoryRepository } from './repository/user-book-history.repository';
 import { UserRepository } from 'src/user/repository/user.repository';
+import { UserBookHistoryReqDto } from './dtos/user-book-history-req.dto';
 
 @Injectable()
 export class HistoryService {
@@ -19,20 +20,30 @@ export class HistoryService {
     private readonly logger: LoggerService,
   ) {}
 
-  async getUserBookHistory(userId: number): Promise<UserBookHistoryResDto[]> {
-    const resultArray = await this.userBookHistoryRepository.find({
-      where: { userId: userId },
-      order: { createdAt: 'DESC' },
-    });
-    if (resultArray.length == 0) {
-      this.logger.error(
-        `## getUserBookHistory can not find book userId : ${userId}, resultArray : ${JSON.stringify(
-          resultArray,
-        )}`,
+  async getUserBookHistory(
+    userId: number,
+    userBookHistoryReqDto: UserBookHistoryReqDto,
+  ): Promise<UserBookHistoryResDto[]> {
+    // if (userBookHistoryReqDto.bookshelfBookId) {
+    //   return await this.getUserBookHistoryByBookshelfBook(
+    //     userId,
+    //     userBookHistoryReqDto.bookshelfBookId,
+    //   );
+    // }
+    const resultArray =
+      await this.userBookHistoryRepository.getPaginatedUserBookHistory(
+        userId,
+        userBookHistoryReqDto,
       );
-      throw HistoryNotFound();
-    }
-    return this.processHistoryList(resultArray);
+    // if (resultArray[1] == 0) {
+    //   this.logger.error(
+    //     `## getUserBookHistory can not find book userId : ${userId}, resultArray : ${JSON.stringify(
+    //       resultArray,
+    //     )}`,
+    //   );
+    //   throw HistoryNotFound();
+    // } 리스트를 반환받을 때 NotFOund는 의도되지 않은 에러.
+    return this.processHistoryList(resultArray); //포맷 수정 필요
   }
 
   async getUserBookHistoryByBookshelfBook(

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -9,6 +9,10 @@ import { UserBookHistoryResDto } from './dtos/UserBookHistoryRes.dto';
 import { UserBookHistoryRepository } from './repository/user-book-history.repository';
 import { UserRepository } from 'src/user/repository/user.repository';
 import { UserBookHistoryReqDto } from './dtos/user-book-history-req.dto';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { toDate } from 'date-fns-tz';
+import { PaginatedUserBookHistoryRes } from './dtos/paginated-user-book-history-res.dto';
 
 @Injectable()
 export class HistoryService {
@@ -23,46 +27,37 @@ export class HistoryService {
   async getUserBookHistory(
     userId: number,
     userBookHistoryReqDto: UserBookHistoryReqDto,
-  ): Promise<UserBookHistoryResDto[]> {
-    // if (userBookHistoryReqDto.bookshelfBookId) {
-    //   return await this.getUserBookHistoryByBookshelfBook(
-    //     userId,
-    //     userBookHistoryReqDto.bookshelfBookId,
-    //   );
-    // }
+  ): Promise<PaginatedUserBookHistoryRes> {
     const resultArray =
       await this.userBookHistoryRepository.getPaginatedUserBookHistory(
         userId,
         userBookHistoryReqDto,
       );
-    // if (resultArray[1] == 0) {
-    //   this.logger.error(
-    //     `## getUserBookHistory can not find book userId : ${userId}, resultArray : ${JSON.stringify(
-    //       resultArray,
-    //     )}`,
-    //   );
-    //   throw HistoryNotFound();
-    // } 리스트를 반환받을 때 NotFOund는 의도되지 않은 에러.
-    return this.processHistoryList(resultArray); //포맷 수정 필요
+    const userBookHistoryList = this.processHistoryList(
+      resultArray.slice(0, 10),
+    );
+    const hasNextPage = resultArray.length == 11;
+    const cursorId = hasNextPage ? resultArray[9].userBookHistoryId : null;
+
+    return new PaginatedUserBookHistoryRes(
+      userBookHistoryList,
+      cursorId,
+      hasNextPage,
+    );
   }
 
-  async getUserBookHistoryByBookshelfBook(
-    userId: number,
-    bookshelfBookId: number,
-  ): Promise<UserBookHistoryResDto[]> {
-    const resultArray = await this.userBookHistoryRepository.find({
-      where: { userId: userId, bookshelfBookId: bookshelfBookId },
-      order: { createdAt: 'DESC' },
+  async getRecentUserBookHistory(
+    userId,
+    userBookHistoryReqDto: UserBookHistoryReqDto,
+  ): Promise<UserBookHistoryResDto> {
+    const whereOptions = { userId: userId };
+    if (userBookHistoryReqDto.bookshelfBookId)
+      whereOptions['bookshelfBookId'] = userBookHistoryReqDto.bookshelfBookId;
+    const history = await this.userBookHistoryRepository.findOne({
+      where: whereOptions,
     });
-    // if (resultArray.length == 0) {
-    //   this.logger.error(
-    //     `## can not find book history userId : ${userId}, bookshelfBookId : ${bookshelfBookId}`,
-    //   );
-    //   throw HistoryNotFound();
-    // }
-    return this.processHistoryList(resultArray);
+    return UserBookHistoryResDto.makeRes(history);
   }
-
   async createUserBookHistory(
     userId: number,
     createUserBookHistoryDto: CreateUserBookHistoryDto,
@@ -92,11 +87,28 @@ export class HistoryService {
     );
   }
 
-  processHistoryList(resultArray: any): UserBookHistoryResDto[] {
-    const userBookHistoryList = [];
-    resultArray.map((history: UserBookHistory) => {
-      userBookHistoryList.push(UserBookHistoryResDto.makeRes(history));
+  processHistoryList(
+    resultArray: UserBookHistory[],
+  ): Record<string, UserBookHistoryResDto[]> {
+    const userBookHistoryList: Record<string, UserBookHistoryResDto[]> = {};
+
+    resultArray.forEach((history: UserBookHistory) => {
+      const createdAtInKST = toDate(history.createdAt, {
+        timeZone: 'Asia/Seoul',
+      });
+      const koFormat = format(createdAtInKST, 'yyyy년 M월 d일 EEEE', {
+        locale: ko,
+      });
+
+      if (!userBookHistoryList[koFormat]) {
+        userBookHistoryList[koFormat] = [];
+      }
+
+      userBookHistoryList[koFormat].push(
+        UserBookHistoryResDto.makeRes(history),
+      );
     });
+
     return userBookHistoryList;
   }
 }

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -55,6 +55,7 @@ export class HistoryService {
       whereOptions['bookshelfBookId'] = userBookHistoryReqDto.bookshelfBookId;
     const history = await this.userBookHistoryRepository.findOne({
       where: whereOptions,
+      order: { createdAt: 'DESC' },
     });
     return UserBookHistoryResDto.makeRes(history);
   }

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -13,6 +13,7 @@ import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { toDate } from 'date-fns-tz';
 import { PaginatedUserBookHistoryRes } from './dtos/paginated-user-book-history-res.dto';
+import { HISTORY_LIST_TAKE } from 'src/common/constant/history.constant';
 
 @Injectable()
 export class HistoryService {
@@ -34,10 +35,12 @@ export class HistoryService {
         userBookHistoryReqDto,
       );
     const userBookHistoryList = this.processHistoryList(
-      resultArray.slice(0, 10),
+      resultArray.slice(0, HISTORY_LIST_TAKE),
     );
-    const hasNextPage = resultArray.length == 11;
-    const cursorId = hasNextPage ? resultArray[9].userBookHistoryId : null;
+    const hasNextPage = resultArray.length == HISTORY_LIST_TAKE + 1;
+    const cursorId = hasNextPage
+      ? resultArray[HISTORY_LIST_TAKE - 1].userBookHistoryId
+      : null;
 
     return new PaginatedUserBookHistoryRes(
       userBookHistoryList,
@@ -51,8 +54,9 @@ export class HistoryService {
     userBookHistoryReqDto: UserBookHistoryReqDto,
   ): Promise<UserBookHistoryResDto> {
     const whereOptions = { userId: userId };
-    if (userBookHistoryReqDto.bookshelfBookId)
+    if (userBookHistoryReqDto.bookshelfBookId) {
       whereOptions['bookshelfBookId'] = userBookHistoryReqDto.bookshelfBookId;
+    }
     const history = await this.userBookHistoryRepository.findOne({
       where: whereOptions,
       order: { createdAt: 'DESC' },

--- a/src/history/repository/user-book-history.repository.ts
+++ b/src/history/repository/user-book-history.repository.ts
@@ -64,14 +64,10 @@ export class UserBookHistoryRepository extends Repository<UserBookHistory> {
     if (cursorId) {
       whereOptions['userBookHistoryId'] = LessThan(cursorId);
     }
-    try {
-      return await this.find({
-        where: whereOptions,
-        order: { createdAt: 'DESC' },
-        take: take,
-      });
-    } catch (e) {
-      console.log(e);
-    }
+    return await this.find({
+      where: whereOptions,
+      order: { createdAt: 'DESC' },
+      take: take,
+    });
   }
 }

--- a/src/history/repository/user-book-history.repository.ts
+++ b/src/history/repository/user-book-history.repository.ts
@@ -1,6 +1,7 @@
+import { UserBookHistoryReqDto } from './../dtos/user-book-history-req.dto';
 import { Injectable } from '@nestjs/common';
 import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, LessThan, Repository } from 'typeorm';
 
 @Injectable()
 export class UserBookHistoryRepository extends Repository<UserBookHistory> {
@@ -46,6 +47,28 @@ export class UserBookHistoryRepository extends Repository<UserBookHistory> {
     return await this.findOne({
       where: { bookshelfBookId: bookshelfBookId },
       order: { endPage: 'DESC' },
+    });
+  }
+
+  async getPaginatedUserBookHistory(
+    userId: number,
+    userBookHistoryReqDto: UserBookHistoryReqDto,
+  ) {
+    const take = 10;
+    const { bookshelfBookId, cursorId } = userBookHistoryReqDto;
+    const whereOptions = { userId: userId };
+
+    if (bookshelfBookId) {
+      whereOptions['bookshelfBookId'] = bookshelfBookId;
+    }
+    if (cursorId) {
+      whereOptions['id'] = LessThan(cursorId);
+    }
+
+    return await this.findAndCount({
+      where: whereOptions,
+      order: { createdAt: 'DESC' },
+      take: take,
     });
   }
 }

--- a/src/history/repository/user-book-history.repository.ts
+++ b/src/history/repository/user-book-history.repository.ts
@@ -62,13 +62,16 @@ export class UserBookHistoryRepository extends Repository<UserBookHistory> {
       whereOptions['bookshelfBookId'] = bookshelfBookId;
     }
     if (cursorId) {
-      whereOptions['id'] = LessThan(cursorId);
+      whereOptions['userBookHistoryId'] = LessThan(cursorId);
     }
-
-    return await this.find({
-      where: whereOptions,
-      order: { createdAt: 'DESC' },
-      take: take,
-    });
+    try {
+      return await this.find({
+        where: whereOptions,
+        order: { createdAt: 'DESC' },
+        take: take,
+      });
+    } catch (e) {
+      console.log(e);
+    }
   }
 }

--- a/src/history/repository/user-book-history.repository.ts
+++ b/src/history/repository/user-book-history.repository.ts
@@ -54,7 +54,7 @@ export class UserBookHistoryRepository extends Repository<UserBookHistory> {
     userId: number,
     userBookHistoryReqDto: UserBookHistoryReqDto,
   ) {
-    const take = 10;
+    const take = 11;
     const { bookshelfBookId, cursorId } = userBookHistoryReqDto;
     const whereOptions = { userId: userId };
 
@@ -65,7 +65,7 @@ export class UserBookHistoryRepository extends Repository<UserBookHistory> {
       whereOptions['id'] = LessThan(cursorId);
     }
 
-    return await this.findAndCount({
+    return await this.find({
       where: whereOptions,
       order: { createdAt: 'DESC' },
       take: take,

--- a/src/history/repository/user-book-history.repository.ts
+++ b/src/history/repository/user-book-history.repository.ts
@@ -1,5 +1,6 @@
 import { UserBookHistoryReqDto } from './../dtos/user-book-history-req.dto';
 import { Injectable } from '@nestjs/common';
+import { HISTORY_LIST_TAKE } from 'src/common/constant/history.constant';
 import { UserBookHistory } from 'src/model/entity/UserBookHistory.entity';
 import { DataSource, LessThan, Repository } from 'typeorm';
 
@@ -54,7 +55,7 @@ export class UserBookHistoryRepository extends Repository<UserBookHistory> {
     userId: number,
     userBookHistoryReqDto: UserBookHistoryReqDto,
   ) {
-    const take = 11;
+    const take = HISTORY_LIST_TAKE + 1;
     const { bookshelfBookId, cursorId } = userBookHistoryReqDto;
     const whereOptions = { userId: userId };
 

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -33,7 +33,6 @@ export class MemoService {
     );
     const resultArray = resultObject.resultArray;
 
-    if (resultArray.length == 0) throw MemoNotFoundException();
     await Promise.all(
       resultArray.map(async (memo) => {
         const hashtags = await this.getHashtagsByMemoId(memo.memoId);
@@ -75,7 +74,7 @@ export class MemoService {
     const selectedHashtag = await this.hashtagRepository.findOne({
       where: { keyword: hashtag },
     });
-    if (!selectedHashtag) throw HashtagNotFoundException();
+    if (!selectedHashtag) throw HashtagNotFoundException(); //해당하는 해시태그가 존재하지 않는 경우
     const resultObject = await this.memoHashtagRepository.getMemoListByHashtag(
       userId,
       selectedHashtag.hashtagId,
@@ -84,7 +83,6 @@ export class MemoService {
     const resultArray = resultObject.resultArray;
     const totalResults = Number(resultObject.totalResults[0].total_results);
 
-    if (resultArray.length == 0) throw MemoNotFoundException();
     const memoList = await this.processMemoList(resultArray);
 
     return MemoResWithPagesDto.makeRes(
@@ -106,7 +104,6 @@ export class MemoService {
       (page - 1) * 10,
     );
     const resultArray = resultObject.resultArray;
-    if (resultArray.length == 0) throw MemoNotFoundException();
 
     // return await this.processMemoList(resultArray);
     return MemoResWithPagesDto.makeRes(
@@ -137,7 +134,7 @@ export class MemoService {
         memoId: memoId,
       },
     });
-    if (!memo) throw MemoNotFoundException();
+    if (!memo) throw MemoNotFoundException(); //해당 메모 ID로 검색되는 메모가 존재하지 않음
 
     const hashtags = await this.getHashtagsByMemoId(memoId);
 
@@ -202,7 +199,7 @@ export class MemoService {
       where: { memoId: memoId },
     });
 
-    if (!existingMemo) throw MemoNotFoundException();
+    if (!existingMemo) throw MemoNotFoundException(); //해당하는 ID의 메모가 존재하지 않음
 
     existingMemo.content = content;
     existingMemo.page = Number(page);
@@ -233,7 +230,7 @@ export class MemoService {
     const deletedMemo = await this.memoRepository.findOne({
       where: { memoId: memoId, userId: userId },
     });
-    if (!deletedMemo) throw MemoNotFoundException(); //Error;
+    if (!deletedMemo) throw MemoNotFoundException(); //해당하는 ID의 메모가 존재하지 않음
     await this.memoRepository.softDelete({ memoId: memoId, userId: userId });
     return `memoId : ${memoId} is deleted successfully`;
   }


### PR DESCRIPTION
## Description
- 독서 기록 검색에 대한 커서 기반 페이지네이션 구현
- 커서는 userBookHistoryId를 사용. 내림차순 고정, take는 10 고정
- query string으로 cursorId와 bookshelfBookId를 받고, 둘 다 nullable
- meta에 포함되는 cursorId를 다음 페이지 요청 시(더 보기)에 쿼리에 첨부해서 보내면 다음 페이지 불러올 수 있음
## To Discuss

- 피그마에 올라와있는 화면대로면 일단은 전체 독서 기록 조회는 생각하지 않는 것 같아서 일부러 책 이름을 넣지는 않았는데, 필요할 것 같으면 말해주세요
- take 크기도 10이 너무 큰 것 같으면 조정할 수 있어요
## Test
- 

## ETC
페이지네이션된 응답 포맷은 디코 reafy-be에 올린거 참고해주세요

## Related Issues
- Related to #46 